### PR TITLE
Updated build script to download dependency

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -4,6 +4,9 @@ echo ""
 rm -rf dist
 mkdir -p dist
 
+echo "Download Dependency"
+go get github.com/ghodss/yaml
+
 echo "Compiling for OSX"
 GOOS=darwin GOARCH=amd64 go build -o dist/yaml2json-darwin-amd64 main.go
 chmod +x dist/yaml2json-darwin-amd64


### PR DESCRIPTION
Hello,

A very small update. It is a good idea to add the dependency `github.com/ghodss/yaml` in the build script so that the script doesn't fail for someone (like it did for me) who hasn't downloaded it in his/her `GOPATH`.

Cheers,
Vikas